### PR TITLE
🐛 Fix all the broken links and add a Link linter

### DIFF
--- a/.404-links.yml
+++ b/.404-links.yml
@@ -1,0 +1,7 @@
+pullRequestReview: true
+ignore: 
+  urls: # Array of url to ignore
+    - https://www.linkedin.com/in/nadiamedkouri/ #myterious reason the link return a 999
+    - https://leetcode.com #website hates the crawler
+    - https://www.udemy.com #website hates the crawler
+    - https://www2.ccs.neu.edu/research/demeter/papers/law-of-demeter/oopsla88-law-of-demeter.pdf

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -2,7 +2,7 @@ name: Markdown lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
     types: [assigned, opened, synchronize, reopened]
 

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,0 +1,17 @@
+name: Markdown lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types: [assigned, opened, synchronize, reopened]
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: 'restqa-404-links'
+      uses: restqa/404-links@3.1.4
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/en/chapters/10-architecture/6-object-oriented-programming.md
+++ b/en/chapters/10-architecture/6-object-oriented-programming.md
@@ -40,7 +40,7 @@ If you want to continue to really dig into object-oriented programming, here are
 - [Inheritance Is Not Subtyping](https://www.cs.utexas.edu/~wcook/papers/InheritanceSubtyping90/CookPOPL90.pdf)
 - [A Behavioral Notion of Subtyping](https://www.cs.cmu.edu/~wing/publications/LiskovWing94.pdf)
 - [A Denotational Semantics of Inheritance](https://www.cs.utexas.edu/~wcook/papers/thesis/cook89.pdf)
-- [Representing Type Information in Dynamically Typed Languages](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.39.4394&rep=rep1&type=pdf)
+- [Representing Type Information in Dynamically Typed Languages](https://www.cs.arizona.edu/sites/default/files/TR93-27.pdf)
 - [Concurrent Object-Oriented Programming in Act 1](https://web.media.mit.edu/~lieber/Lieberary/OOP/Act-1/Concurrent-OOP-in-Act-1.html)
 - [The Power of Interoperability: Why Objects Are Inevitable](http://www.cs.cmu.edu/~aldrich/papers/objects-essay.pdf)
 - [Law of demeter](https://www2.ccs.neu.edu/research/demeter/papers/law-of-demeter/oopsla88-law-of-demeter.pdf)

--- a/en/chapters/11-monitoring/1-introduction.md
+++ b/en/chapters/11-monitoring/1-introduction.md
@@ -25,7 +25,7 @@ Other resources related to Node.js monitoring:
 
 Links and resources for HTTP API monitoring:
 
-- [Health Check Response Format for HTTP APIs](https://tools.ietf.org/id/draft-inadarei-api-health-check-01.html)
+- [Health Check Response Format for HTTP APIs](https://datatracker.ietf.org/doc/html/draft-inadarei-api-health-check.html)
 
 ## Logs
 

--- a/en/chapters/4-typescript/3-resources.md
+++ b/en/chapters/4-typescript/3-resources.md
@@ -18,7 +18,7 @@ Anyway, here are some links
 - **[Intermediate]** [Learn Advanced TypeScript Types](https://medium.com/free-code-camp/typescript-curry-ramda-types-f747e99744ab)
 - **[Intermediate]** [Advanced TypeScript Types cheat sheet (with examples)](https://dev.to/ibrahima92/advanced-typescript-types-cheat-sheet-with-examples-5414)
 - **[To know]** [JSDoc typings: all the benefits of TypeScript, with none of the drawbacks](https://gils-blog.tayar.org/posts/jsdoc-typings-all-the-benefits-none-of-the-drawbacks/)
-- **[To know]** [Duck Typing in JavaScript and TypeScript](https://blog.bitsrc.io/duck-typing-in-javascript-and-typescript-7cc834fadd64)
+- **[To know]** [Duck Typing in JavaScript and TypeScript](https://www.geeksforgeeks.org/typescript-duck-typing/)
 
 Some articles by Dr. Axel Rauschmayer:
 

--- a/en/chapters/5-nodejs/1-introduction.md
+++ b/en/chapters/5-nodejs/1-introduction.md
@@ -4,7 +4,8 @@
 
 As a first step, it is really important to understand what Node.js is. Node.js is a JavaScript runtime using the V8 engine of Google Chrome. Node is not a programming language or even a framework.
 
-Node.js is a composition of code and libraries including Libuv, OpenSSL, Zlib ([full list here](https://nodejs.org/en/docs/meta/topics/dependencies/)). All this will allow us, as developers, to interact through different protocols (http, tcp/ip, udp). with the file system of your computer, the network etc…
+Node.js is a composition of code and libraries including Libuv, OpenSSL, Zlib... All this will allow us, as developers, to interact through different protocols such as http, tcp/ip, 
+ or udp with your computer file system, network etc…
 
 Node.js is like a toolbox that can allow you to realize a vast amount of projects of various nature (and not only http APIs as many think... for example [NodeSecure](https://github.com/NodeSecure)). That's why we'll talk about runtime environments.
 

--- a/en/chapters/5-nodejs/10-modules.md
+++ b/en/chapters/5-nodejs/10-modules.md
@@ -38,7 +38,7 @@ I recommend you to listen to the following talks to better understand the subjec
 
 Articles related to ESM
 
-- [Get Ready For ESM - Sindresorhus](https://blog.sindresorhus.com/get-ready-for-esm-aa53530b3f77)
+- [Get Ready For ESM - Sindresorhus](https://gist.github.com/suntong/495573d515a086198154597968b75ee2)
 - [Pure ESM package - Sindresorhus](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)
 - [Using ES Modules (ESM) in Node.js: A Practical Guide (Part 1](https://gils-blog.tayar.org/posts/using-jsm-esm-in-nodejs-a-practical-guide-part-1/)
 

--- a/en/chapters/5-nodejs/12-unit-testing-and-coverage.md
+++ b/en/chapters/5-nodejs/12-unit-testing-and-coverage.md
@@ -33,7 +33,7 @@ For example, learning TDD and other methodologies will be beneficial to add stri
 
 Here are some links to help you make a first "opinion":
 
-- [Why Most Unit Testing is Waste](https://rbcs-us.com/documents/Why-Most-Unit-Testing-is-Waste.pdf)
+- [Why Most Unit Testing is Waste](https://gist.github.com/ktzar/596ee5aae7c41f2e585331e4b71d1e2c)
 - [Test-induced design damage.](https://dhh.dk/2014/test-induced-design-damage.html)
 - [TDD is dead. Long live testing.](https://dhh.dk/2014/tdd-is-dead-long-live-testing.html)
 - [TW Hangouts | Is TDD dead?.](https://www.youtube.com/watch?v=z9quxZsLcfo)

--- a/en/chapters/5-nodejs/3-node-http-ecosystem.md
+++ b/en/chapters/5-nodejs/3-node-http-ecosystem.md
@@ -9,7 +9,7 @@ It is quite common for new developers to start with [express](https://expressjs.
 
 <img src="./../../../assets/nodejs/download-framework.png" alt="download framework" width="600"/>
 
-However [it's not necessarily the best choice](https://dev.to/romainlanz/why-you-should-drop-expressjs-in-2021-711) because the team behind **express** hardly maintains the framework! (**a V5 expected for six years** 🙊) Moreover, many of the patterns they recommend are completely outdated (still no async/await support ...). You'll be writing code that doesn't include any of the modern practices.
+However [it's not necessarily the best choice](https://dev.to/ronanru/stop-using-expressjs-in-202-3kc) because the team behind **express** hardly maintains the framework! (**a V5 expected for six years** 🙊) Moreover, many of the patterns they recommend are completely outdated (still no async/await support ...). You'll be writing code that doesn't include any of the modern practices.
 
 **So how do we choose the right framework?** Well, we should already try to segment these frameworks by family to better understand and discuss the different trade-offs that each solution implies.
 
@@ -76,7 +76,7 @@ You will certainly gain in productivity in the long run (especially if you often
 
 As for the Small-scope, these are purely back-end frameworks. The list of "serious" frameworks is nevertheless quite short because it is really very difficult to build and maintain such projects in the long term:
 
-- [Adonis.js](https://adonisjs.com/) (I also recommend you to read the page [Why Adonis.js ?](https://preview.adonisjs.com/why-adonisjs))
+- [Adonis.js](https://adonisjs.com/) (I also recommend you to read the page [Why Adonis.js ?](https://adonisjs.com/about))
 - [Nest.js](https://nestjs.com/)
 
 ⚠️ **Be careful** because nowadays many old frameworks that are not really maintained anymore are still actively recommended:
@@ -116,7 +116,7 @@ If you rather want to specialize in the back-end then I recommend you to look at
 - [Intro to Fastify - Matteo Collina](https://www.youtube.com/watch?v=FQu8FnTzOR0&feature=emb_logo) (podcast [bonus here](https://webrush.io/episodes/episode-96-expressway-to-fastify-with-matteo-collina)).
 - [Adonis 5 Tour - Romain Lanz](https://www.youtube.com/watch?v=TysfaNcFX_Y&feature=emb_logo)
 
-👀 A recent article by Snyk talks about [the success of Fastify](https://snyk.io/advisor/hub/what-makes-fastify-a-successful-project/).
+👀 A recent article by Snyk talks about [the success of Fastify](https://snyk.io/blog/what-makes-fastify-a-successful-project/).
 
 If you are rather a purist or a low level developer and you like to master everything from A to Z, then it is likely that the small-scope family is for you. It may be interesting for you to explore the different solutions (even if they are not necessarily mainstream).
 

--- a/en/chapters/5-nodejs/6-native-api.md
+++ b/en/chapters/5-nodejs/6-native-api.md
@@ -43,7 +43,7 @@ Bonus:
 Various links to make native addons with Rust rather than C and C++ :
 - [Node.js N-API for Rust.](https://www.youtube.com/watch?v=UzTPBy2acio)
 - [NAPI-RS](https://github.com/napi-rs)
-- [Supercharge Your Node.js With Rust](https://yieldcode.blog/supercharge-nodejs-with-rust/)
+- [Supercharge Your Node.js With Rust](https://www.yieldcode.blog/post/supercharge-nodejs-with-rust/)
 - [Heavy computation in Node.js with Rust - Jean Burellier](https://www.youtube.com/watch?v=yme8ZZqa8NQ)
 
 ---

--- a/en/chapters/5-nodejs/8-packages.md
+++ b/en/chapters/5-nodejs/8-packages.md
@@ -21,7 +21,7 @@ If you have the opportunity or an idea of packages then I strongly recommend you
 
 - [Getting started NPM](https://docs.npmjs.com/getting-started)
 - [NodeSchool - How to NPM](https://github.com/workshopper/how-to-npm)
-- [The package.json guide](https://nodejs.dev/learn/the-package-json-guide)
+- [An introduction to the npm package manager](https://nodejs.org/en/learn/getting-started/an-introduction-to-the-npm-package-manager#packages)
 - [CJ Silverio, CTO of npm](https://www.youtube.com/watch?v=HH3aNjjhMg8)
 - [npm and the Future of JavaScript - Laurie Voss, npm, Inc.](https://www.youtube.com/watch?v=0PU-4GGLzGg)
 - [Radical Modularity - Aria Stewart, npm, Inc.](https://www.youtube.com/watch?v=SsIdWFtp2QA)
@@ -46,7 +46,7 @@ It's a very interesting solution, especially to have only one git repo but still
 - [Simplify your monorepo with npm 7 workspaces](https://dev.to/limal/simplify-your-monorepo-with-npm-7-workspaces-5gmj)
 - [npm Workspaces (RFC)](https://github.com/npm/rfcs/blob/latest/implemented/0026-workspaces.md)
 - [Workspaces in Yarn](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/)
-- [pnpm Workspace](https://pnpm.js.org/en/workspaces)
+- [pnpm Workspace](https://pnpm.io/workspaces)
 - [🐉 A tool for managing JavaScript projects with multiple packages.](https://github.com/lerna/lerna)
 
 I am just starting to use them for different projects, so I will complete the section in the next few months.

--- a/en/chapters/5-nodejs/9-debugging-and-profiling.md
+++ b/en/chapters/5-nodejs/9-debugging-and-profiling.md
@@ -8,7 +8,7 @@ Improving on topics like debugging is very important as a developer in order not
 
 Here is a list of resources that you may need to read:
 
-- [Node.js debugging best practices - Joyent](https://www.joyent.com/node-js/production/debug)
+- [Node.js debugging best practices](https://www.tritondatacenter.com/node-js/production/debug)
 - [Node.js official debugging guide](https://nodejs.org/en/docs/guides/debugging-getting-started/)
 - [Node.js debugger API](https://nodejs.org/api/debugger.html)
 - [VS Code integrated tools for Node.js](https://code.visualstudio.com/docs/nodejs/nodejs-tutorial#_debugging-your-node-application)

--- a/en/chapters/6-database/7-redis.md
+++ b/en/chapters/6-database/7-redis.md
@@ -23,7 +23,7 @@ Articles or talks:
 - [Solving Head-Of-Line blocking with auto pipelining, NearForm](https://www.youtube.com/watch?v=0L0ER4pZbX4)
 - [What is Distributed Caching? Explained with Redis!](https://www.youtube.com/watch?v=U3RkDLtS7uY)
 
-For more talks around Redis, do not hesitate to consult the [Redis Labs](https://www.youtube.com/c/Redislabs/featured) youtube channel.
+For more talks around Redis, do not hesitate to consult the [Redis Inc](https://www.youtube.com/@Redisinc) youtube channel.
 
 ---
 

--- a/en/chapters/8-security/6-ast.md
+++ b/en/chapters/8-security/6-ast.md
@@ -2,7 +2,7 @@
 
 ## Static Analysis & AST
 
-As part of my [NodeSecure](https://github.com/NodeSecure/cli) project, one of my objectives was to succeed in detecting various and varied “malicious” codes that have been listed through various attacks (several can be found on [badjs](https://badjs.org/)).
+As part of my [NodeSecure](https://github.com/NodeSecure/cli) project, one of my objectives was to succeed in detecting various and varied “malicious” codes that have been listed through various attacks.
 
 When we talk about static analysis, it is therefore a question of analyzing a source code without ever executing it (otherwise it is rather a dynamic analysis). For this we will transform the code into AST format which will make the analysis of the code much simpler.
 

--- a/fr/chapters/10-architecture/5-oop.md
+++ b/fr/chapters/10-architecture/5-oop.md
@@ -42,7 +42,7 @@ Si vous souhaitez continuer à réellement creuser la programmation orientée ob
 * [Inheritance Is Not Subtyping](https://www.cs.utexas.edu/~wcook/papers/InheritanceSubtyping90/CookPOPL90.pdf)
 * [A Behavioral Notion of Subtyping](https://www.cs.cmu.edu/~wing/publications/LiskovWing94.pdf)
 * [A Denotational Semantics of Inheritance](https://www.cs.utexas.edu/~wcook/papers/thesis/cook89.pdf)
-* [Representing Type Information in Dynamically Typed Languages](https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.39.4394&rep=rep1&type=pdf)
+- [Representing Type Information in Dynamically Typed Languages](https://www.cs.arizona.edu/sites/default/files/TR93-27.pdf)
 * [Concurrent Object-Oriented Programming in Act 1](https://web.media.mit.edu/~lieber/Lieberary/OOP/Act-1/Concurrent-OOP-in-Act-1.html)
 * [The Power of Interoperability: Why Objects Are Inevitable](http://www.cs.cmu.edu/~aldrich/papers/objects-essay.pdf)
 * [Law of demeter](https://www2.ccs.neu.edu/research/demeter/papers/law-of-demeter/oopsla88-law-of-demeter.pdf)

--- a/fr/chapters/11-monitoring/1-monitoring.md
+++ b/fr/chapters/11-monitoring/1-monitoring.md
@@ -23,7 +23,7 @@ Autres ressources en lien avec le monitoring Node.js :
 ## API
 Liens et ressources pour du monitoring d’API HTTP :
 
-- [Health Check Response Format for HTTP APIs](https://tools.ietf.org/id/draft-inadarei-api-health-check-01.html)
+- [Health Check Response Format for HTTP APIs](https://datatracker.ietf.org/doc/html/draft-inadarei-api-health-check.html)
 
 ## Logs
 Liens et ressources pour du monitoring de logs :

--- a/fr/chapters/2-javascript/4-online-courses-talks-articles.md
+++ b/fr/chapters/2-javascript/4-online-courses-talks-articles.md
@@ -66,7 +66,7 @@ J’ai tout récemment ré-exploré le blog de Jake et franchement je ne me souv
 
 #### Surma
 
-Aussi un excellent développeur et vulgarisateur de concepts et fonctionnalités autour du Web (JavaScript et plus). Je vous recommande donc fortement d’aller lire son blog [surma.dev](https://surma.dev/things/index.htm>)!
+Aussi un excellent développeur et vulgarisateur de concepts et fonctionnalités autour du Web (JavaScript et plus). Je vous recommande donc fortement d’aller lire son blog [surma.dev](https://surma.dev/things/index.htm)!
 
 - EN **[A savoir]** [My most useful RegExp trick](https://surma.dev/things/regexp-quote/index.html)
 - EN **[Intermédiaire]** [Deep-copying in JavaScript](https://surma.dev/things/deep-copy/index.html)

--- a/fr/chapters/3-ecmascript/4-tc39.md
+++ b/fr/chapters/3-ecmascript/4-tc39.md
@@ -12,7 +12,7 @@ En 2018 nous avions organisé FR [un Weektalk](https://www.youtube.com/watch?v=_
 
 Autres liens:
 
-- EN [Archives d’ECMAScript](https://www.ecma-international.org/ecmascript-development-archive/https://www.ecma-international.org/ecmascript-development-archive/)
+- EN [Archives d’ECMAScript](https://www.ecma-international.org/ecmascript-development-archive)
 - EN [ECMAScript forum](https://es.discourse.group/)
 - EN [ES Discuss (Forum d'échange sur ECMAScript)](https://esdiscuss.org/)
 

--- a/fr/chapters/4-typescript/3-ressources.md
+++ b/fr/chapters/4-typescript/3-ressources.md
@@ -18,7 +18,7 @@ Voici néanmoins quelques liens :
 - EN  **[Intermédiaire]** [Learn Advanced TypeScript Types](https://medium.com/free-code-camp/typescript-curry-ramda-types-f747e99744ab)
 - EN  **[Intermédiaire]** [Advanced TypeScript Types cheat sheet (with examples)](https://dev.to/ibrahima92/advanced-typescript-types-cheat-sheet-with-examples-5414)
 - EN  **[A savoir]** [JSDoc typings: all the benefits of TypeScript, with none of the drawbacks](https://gils-blog.tayar.org/posts/jsdoc-typings-all-the-benefits-none-of-the-drawbacks/)
-- EN  **[A savoir]** [Duck Typing in JavaScript and TypeScript](https://blog.bitsrc.io/duck-typing-in-javascript-and-typescript-7cc834fadd64)
+- EN  **[A savoir]** [Duck Typing in JavaScript and TypeScript](https://www.geeksforgeeks.org/typescript-duck-typing/)
 
 Quelques articles du Dr. Axel Rauschmayer:
 

--- a/fr/chapters/5-nodejs/1-introduction.md
+++ b/fr/chapters/5-nodejs/1-introduction.md
@@ -4,7 +4,7 @@
 
 Node.js est un [runtime](https://fr.wikipedia.org/wiki/Environnement_d%27ex%C3%A9cution#:~:text=Un%20environnement%20d'ex%C3%A9cution%20ou,un%20langage%20de%20programmation%20donn%C3%A9.) JavaScript utilisant le moteur [V8](https://v8.dev/) de Google Chrome. **<u>Node n’est pas un langage de programmation ni même un framework</u>**.
 
-Node.js est une composition de code et librairies dont Libuv, OpenSSL, Zlib ([liste complète ici](https://nodejs.org/en/docs/meta/topics/dependencies/)). Tout cela va nous permettre, en tant que développeurs, de pouvoir interagir par le biais de différents protocoles (http, tcp/ip, udp). avec le système de fichiers de votre ordinateur, le réseau etc...
+Node.js est une composition de code et librairies dont Libuv, OpenSSL, Zlib...  Tout cela va nous permettre, en tant que développeurs, de pouvoir interagir par le biais de différents protocoles tels que http, tcp/ip ou udp avec le système de fichiers de votre ordinateur, le réseau etc...
 
 Node.js est comme une boîte d’outils qui peut vous permettre de réaliser une vaste quantité de projets de nature diverses et variées (et pas seulement des API http comme beaucoup le pensent… par exemple [NodeSecure](https://github.com/ES-Community/nsecure) ou [SlimIO](https://github.com/SlimIO)). C’est pour cela que l'on parlera d’environnement d’exécution.
 

--- a/fr/chapters/5-nodejs/10-modules.md
+++ b/fr/chapters/5-nodejs/10-modules.md
@@ -39,7 +39,7 @@ Je vous recommande d’écouter les talks suivant pour mieux comprendre le sujet
 Articles en lien avec ESM
 
 - FR **[Débutant]** [ESM et CJS - le match](https://www.audreydoyen.com/blog/ESM-et-CJS)
-- [Get Ready For ESM - Sindresorhus](https://blog.sindresorhus.com/get-ready-for-esm-aa53530b3f77)
+- [Get Ready For ESM - Sindresorhus](https://gist.github.com/suntong/495573d515a086198154597968b75ee2)
 - [Pure ESM package - Sindresorhus](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)
 - 🆕 [Using ES Modules (ESM) in Node.js: A Practical Guide (Part 1](https://gils-blog.tayar.org/posts/using-jsm-esm-in-nodejs-a-practical-guide-part-1/)
 

--- a/fr/chapters/5-nodejs/12-test-unitaire-et-coverage.md
+++ b/fr/chapters/5-nodejs/12-test-unitaire-et-coverage.md
@@ -34,7 +34,7 @@ Par exemple, apprendre TDD et autres méthodologies sera bénéfique pour ajoute
 Quelques liens pour vous faire une “opinion”:
 
 - FR [BDD, DDD, ATDD et TDD expliqués !](https://www.youtube.com/watch?v=jxBmKvS7lAo)
-- EN [Why Most Unit Testing is Waste](https://rbcs-us.com/documents/Why-Most-Unit-Testing-is-Waste.pdf)
+- EN [Why Most Unit Testing is Waste](https://gist.github.com/ktzar/596ee5aae7c41f2e585331e4b71d1e2c)
 - EN [Test-induced design damage.](https://dhh.dk/2014/test-induced-design-damage.html)
 - EN [TDD is dead. Long live testing.](https://dhh.dk/2014/tdd-is-dead-long-live-testing.html)
 - EN [TW Hangouts | Is TDD dead?.](https://www.youtube.com/watch?v=z9quxZsLcfo)

--- a/fr/chapters/5-nodejs/3-ecosysteme-http-node.md
+++ b/fr/chapters/5-nodejs/3-ecosysteme-http-node.md
@@ -8,7 +8,7 @@ Il est assez fréquent que les nouveaux développeurs commencent avec [express](
 
 <img src="./../../../assets/nodejs/download-framework.png" alt="download framework" width="600"/>
 
-Néanmoins [ce n’est pas forcément le meilleur choix](https://dev.to/romainlanz/why-you-should-drop-expressjs-in-2021-711) car l’équipe derrière **express** maintient difficilement le framework! (**<u>une V5 attendu depuis six ans</u> 🙊**) De plus, beaucoup des patterns qu’ils recommandent sont complètement démodés (toujours pas de support async/await …). Vous allez écrire du code qui n'inclut rien des pratiques modernes.
+Néanmoins [ce n’est pas forcément le meilleur choix](https://dev.to/ronanru/stop-using-expressjs-in-202-3kc) car l’équipe derrière **express** maintient difficilement le framework! (**<u>une V5 attendu depuis six ans</u> 🙊**) De plus, beaucoup des patterns qu’ils recommandent sont complètement démodés (toujours pas de support async/await …). Vous allez écrire du code qui n'inclut rien des pratiques modernes.
 
 **<u>Comment choisir le bon framework alors ?</u>** Eh bien il nous faut déjà essayer de segmenter ces frameworks par famille pour mieux comprendre et débattre des différents trade-offs que chaque solution implique.
 
@@ -118,7 +118,7 @@ Si vous souhaitez plutôt vous spécialiser en back-end alors je vous recommande
 - EN [Adonis 5 Tour - Romain Lanz](https://www.youtube.com/watch?v=TysfaNcFX_Y&feature=emb_logo)
 - FR [**débutant**] [LMHB #3: MONTER UNE APP WEB RAPIDEMENT AVEC ADONIS.JS FEAT @ROMAINLANZ](https://www.youtube.com/watch?v=vcrjgZezaI0&feature=youtu.be)
 
-> 👀 Un récent article de Snyk parle d’ailleurs [du succès de Fastify](https://snyk.io/advisor/hub/what-makes-fastify-a-successful-project/) (en anglais).
+> 👀 Un récent article de Snyk parle d’ailleurs [du succès de Fastify](https://snyk.io/blog/what-makes-fastify-a-successful-project/) (en anglais).
 
 Si vous êtes plutôt un puriste ou un développeur bas niveau et que vous aimez bien tout maîtriser de A à Z, alors il est fort probable que la famille small-scope soit pour vous. Il peut être intéressant pour vous dès lors d’explorer les différentes solutions (même si elles ne sont pas forcément mainstream).
 

--- a/fr/chapters/5-nodejs/6-native-api.md
+++ b/fr/chapters/5-nodejs/6-native-api.md
@@ -48,7 +48,7 @@ Divers liens pour faire des addons natif avec Rust plutôt que C et C++ :
 
 - [Node.js N-API for Rust.](https://www.youtube.com/watch?v=UzTPBy2acio)
 - [NAPI-RS](https://github.com/napi-rs)
-- EN [Supercharge Your Node.js With Rust](https://yieldcode.blog/supercharge-nodejs-with-rust/)
+- EN [Supercharge Your Node.js With Rust](https://www.yieldcode.blog/post/supercharge-nodejs-with-rust/)
 - EN [Heavy computation in Node.js with Rust - Jean Burellier](https://www.youtube.com/watch?v=yme8ZZqa8NQ)
 
 ---

--- a/fr/chapters/5-nodejs/8-packages.md
+++ b/fr/chapters/5-nodejs/8-packages.md
@@ -20,7 +20,6 @@ Si vous avez l’occasion ou une idée de packages alors je vous recommande fort
 
 - EN [Getting started NPM](https://docs.npmjs.com/getting-started)
 - EN [NodeSchool - How to NPM](https://github.com/workshopper/how-to-npm)
-- EN [The package.json guide](https://nodejs.dev/learn/the-package-json-guide)
 - EN [CJ Silverio, CTO of npm](https://www.youtube.com/watch?v=HH3aNjjhMg8)
 - EN [npm and the Future of JavaScript - Laurie Voss, npm, Inc.](https://www.youtube.com/watch?v=0PU-4GGLzGg)
 - EN [Radical Modularity - Aria Stewart, npm, Inc.](https://www.youtube.com/watch?v=SsIdWFtp2QA)
@@ -42,7 +41,7 @@ C’est une solution très intéressante notamment pour n’avoir qu’un seul r
 - EN [Simplify your monorepo with npm 7 workspaces](https://dev.to/limal/simplify-your-monorepo-with-npm-7-workspaces-5gmj)
 - EN [npm Workspaces (RFC)](https://github.com/npm/rfcs/blob/latest/implemented/0026-workspaces.md)
 - EN [Workspaces in Yarn](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/)
-- EN [pnpm Workspace](https://pnpm.js.org/en/workspaces)
+- EN [pnpm Workspace](https://pnpm.io/workspaces)
 - EN [🐉 A tool for managing JavaScript projects with multiple packages.](https://github.com/lerna/lerna)
 
 Je commence pour ma part à peine à les utiliser à travers différents projets, donc je compléterai la section au cours des prochains mois.

--- a/fr/chapters/5-nodejs/9-debugging-profiling.md
+++ b/fr/chapters/5-nodejs/9-debugging-profiling.md
@@ -9,7 +9,7 @@ S’améliorer et s’éveiller sur des sujets comme le debug est très importan
 
 Voici une liste de ressources qui pourraient vous êtres nécessaire de lire :
 
-- EN [Node.js debugging best practices - Joyent](https://www.joyent.com/node-js/production/debug)
+- EN [Node.js debugging best practices](https://www.tritondatacenter.com/node-js/production/debug)
 - EN [Node.js official debugging guide](https://nodejs.org/en/docs/guides/debugging-getting-started/)
 - EN [Node.js debugger API](https://nodejs.org/api/debugger.html)
 - EN [VS Code integrated tools for Node.js](https://code.visualstudio.com/docs/nodejs/nodejs-tutorial#_debugging-your-node-application)

--- a/fr/chapters/6-database/7-redis.md
+++ b/fr/chapters/6-database/7-redis.md
@@ -23,7 +23,7 @@ Articles ou talks:
 - EN [Solving Head-Of-Line blocking with auto pipelining, NearForm](https://www.youtube.com/watch?v=0L0ER4pZbX4)
 - EN 🆕 [What is Distributed Caching? Explained with Redis!](https://www.youtube.com/watch?v=U3RkDLtS7uY)
 
-Pour plus de talks autour de Redis n’hésitez pas à consulter la chaine Youtube [Redis Labs](https://www.youtube.com/c/Redislabs/featured).
+Pour plus de talks autour de Redis n’hésitez pas à consulter la chaine Youtube [Redis Inc](https://www.youtube.com/@Redisinc).
 
 ---
 

--- a/fr/chapters/8-securite/6-analyse-statique-ast.md
+++ b/fr/chapters/8-securite/6-analyse-statique-ast.md
@@ -1,7 +1,7 @@
 # 🔐 Sécurité
 
 ## Analyse statique & AST
-Dans le cadre de mon projet [NodeSecure](https://github.com/NodeSecure/cli), un de mes objectifs était de réussir à détecter des codes “malicieux” divers et variés qui ont été répertoriés à travers diverses attaques (plusieurs peuvent être retrouvés sur [badjs](https://badjs.org/)).
+Dans le cadre de mon projet [NodeSecure](https://github.com/NodeSecure/cli), un de mes objectifs était de réussir à détecter des codes “malicieux” divers et variés qui ont été répertoriés à travers diverses attaques.
 
 Quand nous parlons d’analyse statique, il s’agit donc d’analyser un code source sans jamais l’exécuter (sinon c’est plutôt une analyse dynamique). Pour cela nous allons transformer le code en format AST ce qui va rendre l’analyse du code bien plus simple.
 


### PR DESCRIPTION
Hi,
First of all, thank you for the fantastic work on this ebook.
As I saw there is a 800+ link to external website in this ebook and some of them are broken... 

Then allow me to propose a Github Action that will check the health of each link.

While running it on my fork, I found around 50 links that was broken, see report:

<img width="1782" alt="image" src="https://github.com/fraxken/ebook_nodejs/assets/4768226/0f065730-dad8-42d1-bbd6-ea0069ecade6">

I feel all of them, feel free to review 😄.

The github action use for to link check: https://github.com/marketplace/actions/404-links


---

⚠️ **One important thing**: Since you are deploying the ebook on github page using the traditional way... Activating the github action might the deployement of the page.. (I'm not sure at all about it)
But a good thing would be to try to configure and [deploy on github page using github action](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#creating-a-custom-github-actions-workflow-to-publish-your-site):